### PR TITLE
Fix whitelist entry check in canPass method

### DIFF
--- a/NobleWhitelist/src/main/java/me/nobeld/noblewhitelist/logic/WhitelistChecker.java
+++ b/NobleWhitelist/src/main/java/me/nobeld/noblewhitelist/logic/WhitelistChecker.java
@@ -183,7 +183,11 @@ public class WhitelistChecker {
      */
     public PairData<SuccessData, Boolean> canPass(PlayerWrapper player) {
         Optional<WhitelistEntry> entry = this.data.whitelistData().getEntry(player);
+        if (entry.isPresent() && !entry.get().isWhitelisted()) {
+            entry = Optional.empty();
+        }
 
+        
         boolean enforce = this.data.getConfigD().get(ConfigData.WhitelistCF.enforceNameDiffID);
         if (entry.isPresent() && enforce) {
             CheckType type = checkEntry(entry.get(), player);


### PR DESCRIPTION
With this change, entries with Whitelisted = false are treated as non-existent during the whitelist check. This ensures that the Whitelisted flag acts as a definitive access control switch, allowing administrators or external systems (Discord/Telegram bots/) to temporarily revoke or grant server access without removing player data.